### PR TITLE
basic repo layout for pip and tests, minimal cli that can list devices

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    - id: black
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
-# piconet
-Picoscope remote control server
+# Piconet
+
+Remote control server with built-in web interface and command-line tool for picoscopes.
+
+## Prerequisites
+
+First you need to have Pico SDK installed in your system. For that check out [pico website](https://www.picotech.com/downloads)
+
+## Installation
+
+For development run `pip install -e .` in the root folder of the repository.
+
+TODO: publish on pip
+
+## Usage
+
+The project provides an RPC server and a command-line interface.
+
+### Starting the server
+
+TODO
+
+```sh
+piconetd
+```
+
+### Configuration and command-line arguments
+
+TODO
+
+### Using `piconet-cli`
+
+```sh
+# check out the cli help:
+piconet-cli --help
+# list available devices:
+piconet-cli list
+```
+
+## Development environment
+
+Create a virtual environment and install the module in developer mode:
+
+```sh
+virtualenv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+Install dev requirements and hooks to enforce black:
+
+```sh
+pip install -r dev_requirements.txt
+pre-commit install
+```
+
+Run tests from the root of the repo:
+
+```sh
+pytest
+```
+

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,3 @@
+black
+pre-commit
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+picosdk
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,35 @@
+from setuptools import setup, find_namespace_packages
+
+with open("requirements.txt") as f:
+    install_reqs = f.read().strip().split("\n")
+
+# Filter out comments/hashes from requirements.txt
+reqs = []
+for req in install_reqs:
+    if req.startswith("#") or req.startswith("    --hash="):
+        continue
+    reqs.append(str(req).rstrip(" \\"))
+
+setup(
+    name="piconet",
+    version="0.0.1",
+    license="MIT license",
+    url="https://github.com/quantumgear/piconet",
+    description="RPC server and command line tool for picoscopes",
+    author="Stepan Snigirev, Jan Trautmann",
+    author_email="snigirev.stepan@gmail.com",
+    packages=find_namespace_packages("src", include=["*"]),
+    package_dir={"": "src"},
+    install_requires=reqs,
+    entry_points={
+        "console_scripts": [
+            "piconet-cli=piconet.cli:main",
+            "piconetd=piconet.server:main",
+        ],
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+)

--- a/src/piconet/cli.py
+++ b/src/piconet/cli.py
@@ -73,6 +73,5 @@ def main():
             print(f"No arguments provided. Type `{sys.argv[0]} -h` for help.")
     except PiconetError as e:
         print(f"Error while command:\n  {e}")
-    # we are done - close scopes, just to be safe
-    for device in devices:
-        device.close()
+        # exit with error
+        sys.exit(1)

--- a/src/piconet/cli.py
+++ b/src/piconet/cli.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+from .pico import list_devices
+
+
+class PiconetError(Exception):
+    """Expected exception that doesn't require traceback"""
+
+    pass
+
+
+def parse_args():
+    """Defines cli arguments for the module"""
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument(
+        "--device",
+        "-d",
+        default=None,
+        help="device to use, default - first available device",
+    )
+    subparsers = argparser.add_subparsers(help="command to run", dest="subparser_name")
+    listparser = subparsers.add_parser(
+        "list", help="lists all connected picoscopes and their info"
+    )
+    infoparser = subparsers.add_parser(
+        "info", help="returns information about specific device"
+    )
+    return argparser.parse_args()
+
+
+def print_devices(devices: list) -> None:
+    """Prints a list of connected devices and their info (id and other stuff)"""
+    if not devices:
+        # special print if no devices connected
+        print("No devices found")
+        return
+    print(f"Found {len(devices)} devices:")
+    for device in devices:
+        device_id = device.info.serial.decode()
+        print(f"- [{device_id}] {device.info}")
+
+
+def print_info(device) -> None:
+    print(device.info)
+
+
+def get_device_by_id(devices: list, device_id):
+    for dev in devices:
+        if dev.info.serial.decode() == device_id:
+            return dev
+
+
+def main():
+    args = parse_args()
+    cmd = args.subparser_name
+    devices = list_devices()
+    selected_device = None
+    if args.device is None and devices:
+        selected_device = devices[0]
+    else:
+        selected_device = get_device_by_id(devices, args.device)
+    try:
+        if cmd == "list":
+            print_devices(devices)
+        elif cmd == "info":
+            if not devices:
+                raise PiconetError("No devices connected!")
+            if selected_device is None:
+                raise PiconetError(f"Invalid device id: {args.device}")
+            print_info(selected_device)
+        else:
+            print(f"No arguments provided. Type `{sys.argv[0]} -h` for help.")
+    except PiconetError as e:
+        print(f"Error while command:\n  {e}")
+    # we are done - close scopes, just to be safe
+    for device in devices:
+        device.close()

--- a/src/piconet/pico.py
+++ b/src/piconet/pico.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+from picosdk.discover import find_all_units
+from picosdk.errors import DeviceNotFoundError
+
+
+def list_devices() -> list:
+    # We need to do try-except because picosdk throws an error if no devices connected.
+    # In this case we just return an empty list.
+    try:
+        return find_all_units()
+    except DeviceNotFoundError:
+        return []

--- a/src/piconet/server.py
+++ b/src/piconet/server.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+
+def main():
+    raise NotImplementedError("Server is not implemented yet")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,3 @@
+def test_dummy():
+    """Pretty dummy test not doing anything useful"""
+    assert 2 + 2 == 4


### PR DESCRIPTION
Closes #4 and closes #1. Tackles #2 (pre-commit check in local git, but not on Github)

Overview of the changes:
- `setup.py` and `setup.cfg` tell `pip` where to look for packages, basic package info, console scripts that should be registered in shell etc, so with them one can do `pip install [-e] .`
- `dev_requirements.txt` contains requirements needed for development only
- `requirements.txt` contains requirements for actual usage of the module
- added basic test that is doing nothing, just to have `pytest` showing something
- `.pre-commit-config.yaml` used to force black check on commits to local repo
- `cli.py` contains some initial code we can build on top - parsing arguments, listing connected devices. Nothing else really, but a good starting point.